### PR TITLE
Replace hardcoded repo name in Docker Action workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  REGISTRY: ghcr.io=
+  REGISTRY: ghcr.io
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,9 +40,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile-thirdparty-vtk
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache,mode=max
           push: true
         
       - name: Build and push OpenMPI and PETSc Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
       
       - name: Build and push VTK Docker image
         id: push-vtk

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,13 +31,13 @@ jobs:
   
       - name: Extract metadata (tags, labels) for main Docker image
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       - name: Build and push VTK Docker image
         id: push-vtk
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile-thirdparty-vtk
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk
@@ -47,7 +47,7 @@ jobs:
         
       - name: Build and push OpenMPI and PETSc Docker image
         id: push-petsc
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile-thirdparty-openmpi-petsc
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-openmpi-petsc
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build and push main Docker image
         id: push-main
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile
           build-args: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,11 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: set image name
         run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,7 @@ on:
       - main
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io=
 
 jobs:
   build-and-push-image:
@@ -18,6 +17,9 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: set image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
+        
       - name: Check out repository
         uses: actions/checkout@v4
 
@@ -42,9 +44,9 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           file: ./docker/Dockerfile-thirdparty-vtk
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache,mode=max
           push: true
         
       - name: Build and push OpenMPI and PETSc Docker image
@@ -52,9 +54,9 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           file: ./docker/Dockerfile-thirdparty-openmpi-petsc
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-openmpi-petsc
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-openmpi-petsc:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-openmpi-petsc:buildcache,mode=max
           push: true
 
       - name: Build and push main Docker image
@@ -63,10 +65,10 @@ jobs:
         with:
           file: ./docker/Dockerfile
           build-args: |
-            VTK_IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk
-            OPENMPI_PETSC_IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc
+            VTK_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk
+            OPENMPI_PETSC_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-openmpi-petsc
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build and push Docker image
+name: Build and push Docker images for CardioMechanics and its dependencies
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,9 +42,9 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           file: ./docker/Dockerfile-thirdparty-vtk
-          tags: ${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-vtk
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-vtk:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-vtk:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk:buildcache,mode=max
           push: true
         
       - name: Build and push OpenMPI and PETSc Docker image
@@ -52,9 +52,9 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           file: ./docker/Dockerfile-thirdparty-openmpi-petsc
-          tags: ${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-openmpi-petsc
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-openmpi-petsc:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-openmpi-petsc:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc:buildcache,mode=max
           push: true
 
       - name: Build and push main Docker image
@@ -63,10 +63,10 @@ jobs:
         with:
           file: ./docker/Dockerfile
           build-args: |
-            VTK_IMAGE=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-vtk
-            OPENMPI_PETSC_IMAGE=${{ env.REGISTRY }}/kit-ibt/cardiomechanics/thirdparty-openmpi-petsc
+            VTK_IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-vtk
+            OPENMPI_PETSC_IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/thirdparty-openmpi-petsc
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/kit-ibt/cardiomechanics:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache,mode=max
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,9 +40,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile-thirdparty-vtk
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/thirdparty-vtk:buildcache,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           push: true
         
       - name: Build and push OpenMPI and PETSc Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,11 +11,7 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+    permissions: write-all
     steps:
       - name: set image name
         run: echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> ${GITHUB_ENV}
@@ -37,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       - name: Build and push VTK Docker image
         id: push-vtk

--- a/docker/Dockerfile-thirdparty-vtk
+++ b/docker/Dockerfile-thirdparty-vtk
@@ -19,5 +19,5 @@ WORKDIR $THIRDPARTY_HOME/src/vtk-${VTK_VERSION}
 # we have to rename a variable to avoid a redeclaration under Linux
 RUN echo "Replacing HZ with H_Z in VTK..."
 RUN grep -rl HZ . | xargs sed -i 's/HZ/H_Z/g'
-# RUN mkdir build && cd build && cmake .. -D CMAKE_INSTALL_PREFIX=${prefixPath}/vtk-${VTK_VERSION} && make && make install
+RUN mkdir build && cd build && cmake .. -D CMAKE_INSTALL_PREFIX=${prefixPath}/vtk-${VTK_VERSION} && make && make install
 

--- a/docker/Dockerfile-thirdparty-vtk
+++ b/docker/Dockerfile-thirdparty-vtk
@@ -19,5 +19,5 @@ WORKDIR $THIRDPARTY_HOME/src/vtk-${VTK_VERSION}
 # we have to rename a variable to avoid a redeclaration under Linux
 RUN echo "Replacing HZ with H_Z in VTK..."
 RUN grep -rl HZ . | xargs sed -i 's/HZ/H_Z/g'
-RUN mkdir build && cd build && cmake .. -D CMAKE_INSTALL_PREFIX=${prefixPath}/vtk-${VTK_VERSION} && make && make install
+# RUN mkdir build && cd build && cmake .. -D CMAKE_INSTALL_PREFIX=${prefixPath}/vtk-${VTK_VERSION} && make && make install
 


### PR DESCRIPTION
- Hardcoded Docker image name has been replaced with the GitHub variable GITHUB_REPOSITORY in lowercase so that the action can be run in forks.
- Replace specific commit with semantic versioning for Docker actions.