### PR TITLE
Fixed issues with installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )

--- a/cmake/IBTDefault.cmake
+++ b/cmake/IBTDefault.cmake
@@ -55,7 +55,7 @@
 
 
 
-cmake_minimum_required( VERSION 2.8.4 )
+cmake_minimum_required( VERSION 3.5 )
 
 # Set the preferred C and C++ compilers
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -30,13 +30,23 @@ Additionally, adjust `export AUTOMAKE_JOBS=X` specifically for [Open MPI](https:
 ## Building using CMake
 
 Before continuing with compiling CardioMechanics using [CMake](https://cmake.org), add the following environmental variables to your systems configuration file ( e.g. .bashrc or .zshrc)
+
+If you installed the requirements with homebrew add:
+```
+export kaRootDir=$HOME/CardioMechanics
+export THIRDPARTY_HOME=$kaRootDir/thirdparty
+export PETSC_DIR=/opt/homebrew/opt/petsc
+```
+If you are using [installRequirements.sh](/installRequirements.sh) add:
 ```
 export kaRootDir=$HOME/CardioMechanics
 export THIRDPARTY_HOME=$kaRootDir/thirdparty
 export PETSC_DIR=$THIRDPARTY_HOME/macosx
 export PETSC_ARCH=petsc-v3.19.1
 ```
-and add the location of the executables to your PATH variable (replace macosx with linux if you are on a linux machine).
+In case you did not use either option to install the requirements add the paths `kaRootDir` and `THIRDPARTY_HOME` in the same way as proposed above and edit the path for `PETSC_DIR` according to your actual path.
+
+Next add the location of the executables to your PATH variable (replace macosx with linux if you are on a linux machine).
 ```
 PATH="$PATH:$THIRDPARTY_HOME/macosx/openMPI-64bit/bin"
 PATH="$PATH:$kaRootDir/_build/bin/macosx"
@@ -53,4 +63,16 @@ cmake -S . -B _build
 to create the `_build` folder and compile the code using
 ```
 cmake --build _build
+```
+
+## Troubleshooting
+
+If you experience the following error 
+```
+nlohmann/json.hpp is not found (fatal error)
+```
+you will have to add the nlohmann-json manually. 
+If you used homebrew to install the requirements you will have to include the following line in your .zshrc:
+```
+export CPATH=$CPATH:/opt/homebrew/opt/nlohmann-json/include
 ```

--- a/electrophysiology/src/CellModel/CMakeLists.txt
+++ b/electrophysiology/src/CellModel/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created on Feb 4 2014 by ew095
 
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.5 )
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )

--- a/electrophysiology/src/Lattice/CMakeLists.txt
+++ b/electrophysiology/src/Lattice/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created on Oct 16 2014 by Silvio Bauer
 
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.5 )
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )

--- a/electrophysiology/src/MathBasics/CMakeLists.txt
+++ b/electrophysiology/src/MathBasics/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created on May 5 2015 by ew095
 
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.5 )
 
 include( ../cmake/IBTDefault.cmake )
 

--- a/electrophysiology/src/acCELLerate/CMakeLists.txt
+++ b/electrophysiology/src/acCELLerate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.5 )
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )

--- a/mechanics/CMakeLists.txt
+++ b/mechanics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.5 )
 
 if( DEFINED ENV{kaRootDir} )
     set( kaRootDir $ENV{kaRootDir} )


### PR DESCRIPTION
Changed minimum required cmake version in all 'CMakeLists.txt' since it was not compatible with the current cmake version anymore. 
Edited installation instructions to also guide building from source without using 'installRequirements.sh'. Plus added small troubleshooting section. 